### PR TITLE
fix: add default help when no cmd or no params is set

### DIFF
--- a/esp_idf_nvs_partition_gen/nvs_partition_gen.py
+++ b/esp_idf_nvs_partition_gen/nvs_partition_gen.py
@@ -1045,6 +1045,7 @@ def generate(args, is_encr_enabled=False, encr_key=None):
 def main():
     parser = argparse.ArgumentParser(description=desc_format('ESP NVS partition generation utility'),
                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.set_defaults(func=lambda _: parser.print_help())
     subparser = parser.add_subparsers(title='Commands',
                                       dest='command',
                                       help=desc_format('Run nvs_partition_gen.py {command} -h for additional help'))


### PR DESCRIPTION
Print default help if neither command verbs nor params is set
```
% ./nvs_partition_gen.py
Traceback (most recent call last):
  File "/work/esp-idf-nvs-partition-gen/esp_idf_nvs_partition_gen/./nvs_partition_gen.py", line 1170, in <module>
    main()
  File "/work/esp-idf-nvs-partition-gen/esp_idf_nvs_partition_gen/./nvs_partition_gen.py", line 1166, in main
    args.func(args)
    ^^^^^^^^^
```