### PR TITLE
fix: encrypt sub-command broken by commit 1766cf5 (IDFGH-14062) (IDFGH-14063)

### DIFF
--- a/esp_idf_nvs_partition_gen/nvs_partition_gen.py
+++ b/esp_idf_nvs_partition_gen/nvs_partition_gen.py
@@ -1135,6 +1135,7 @@ def main():
     parser_encr.set_defaults(func=encrypt)
     parser_encr.add_argument('input',
                              default=None,
+                             nargs='+',
                              help=desc_format('Path to CSV file to parse'))
     parser_encr.add_argument('output',
                              default=None,


### PR DESCRIPTION
input files arg for encrypt sub-command needs to be parsed as a list before passing to the generate() function

resolves #10