### PR TITLE
fix: Notify which key caused struct packing error (IDFGH-15259)

### DIFF
--- a/esp_idf_nvs_partition_gen/nvs_partition_gen.py
+++ b/esp_idf_nvs_partition_gen/nvs_partition_gen.py
@@ -428,30 +428,34 @@ class Page(object):
         entry_struct[8:24] = key_array
         entry_struct[8:8 + len(key)] = key.encode()
 
-        if encoding == 'u8':
-            entry_struct[1] = Page.U8
-            struct.pack_into('<B', entry_struct, 24, data)
-        elif encoding == 'i8':
-            entry_struct[1] = Page.I8
-            struct.pack_into('<b', entry_struct, 24, data)
-        elif encoding == 'u16':
-            entry_struct[1] = Page.U16
-            struct.pack_into('<H', entry_struct, 24, data)
-        elif encoding == 'i16':
-            entry_struct[1] = Page.I16
-            struct.pack_into('<h', entry_struct, 24, data)
-        elif encoding == 'u32':
-            entry_struct[1] = Page.U32
-            struct.pack_into('<I', entry_struct, 24, data)
-        elif encoding == 'i32':
-            entry_struct[1] = Page.I32
-            struct.pack_into('<i', entry_struct, 24, data)
-        elif encoding == 'u64':
-            entry_struct[1] = Page.U64
-            struct.pack_into('<Q', entry_struct, 24, data)
-        elif encoding == 'i64':
-            entry_struct[1] = Page.I64
-            struct.pack_into('<q', entry_struct, 24, data)
+        try:
+            if encoding == 'u8':
+                entry_struct[1] = Page.U8
+                struct.pack_into('<B', entry_struct, 24, data)
+            elif encoding == 'i8':
+                entry_struct[1] = Page.I8
+                struct.pack_into('<b', entry_struct, 24, data)
+            elif encoding == 'u16':
+                entry_struct[1] = Page.U16
+                struct.pack_into('<H', entry_struct, 24, data)
+            elif encoding == 'i16':
+                entry_struct[1] = Page.I16
+                struct.pack_into('<h', entry_struct, 24, data)
+            elif encoding == 'u32':
+                entry_struct[1] = Page.U32
+                struct.pack_into('<I', entry_struct, 24, data)
+            elif encoding == 'i32':
+                entry_struct[1] = Page.I32
+                struct.pack_into('<i', entry_struct, 24, data)
+            elif encoding == 'u64':
+                entry_struct[1] = Page.U64
+                struct.pack_into('<Q', entry_struct, 24, data)
+            elif encoding == 'i64':
+                entry_struct[1] = Page.I64
+                struct.pack_into('<q', entry_struct, 24, data)
+        except struct.error as e:
+            print(f"Packing error for '{encoding}' key '{key}' = '{data}': {e}")
+            raise
 
         # Compute CRC
         crc_data = bytearray(b'28')


### PR DESCRIPTION
## Description
Adds a message which specifies which key caused a struct packing error.

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Espressif\python_env\idf5.4_py3.13_env\Lib\site-packages\esp_idf_nvs_partition_gen\__main__.py", line 4, in <module>
    main()
    ~~~~^^
  File "C:\Espressif\python_env\idf5.4_py3.13_env\Lib\site-packages\esp_idf_nvs_partition_gen\nvs_partition_gen.py", line 1319, in main
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "C:\Espressif\python_env\idf5.4_py3.13_env\Lib\site-packages\esp_idf_nvs_partition_gen\nvs_partition_gen.py", line 1173, in generate
    write_entry(nvs_obj, row['key'], row['type'], row['encoding'], row['value'])
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Espressif\python_env\idf5.4_py3.13_env\Lib\site-packages\esp_idf_nvs_partition_gen\nvs_partition_gen.py", line 833, in write_entry
    nvs_instance.write_entry(key, value, encoding, namespace_idx)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Espressif\python_env\idf5.4_py3.13_env\Lib\site-packages\esp_idf_nvs_partition_gen\nvs_partition_gen.py", line 656, in write_entry
    self.cur_page.write_primitive_data(key, int(value), encoding, namespace_idx, self)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Espressif\python_env\idf5.4_py3.13_env\Lib\site-packages\esp_idf_nvs_partition_gen\nvs_partition_gen.py", line 434, in write_primitive_data
    struct.pack_into('<B', entry_struct, 24, data)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: 'B' format requires 0 <= number <= 255

Creating NVS binary with version: V2 - Multipage Blob Support Enabled
Packing error for 'u8' key 'can_en' = '-1': 'B' format requires 0 <= number <= 255
````

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
